### PR TITLE
#50 change rescue location to drop down menu of shelters

### DIFF
--- a/src/lib/components/PrevShelterInfo.svelte
+++ b/src/lib/components/PrevShelterInfo.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
 	import PrevShelterCatId from './PrevShelterCatID.svelte'
 	import PrevShelterNum from './PrevShelterNum.svelte'
+	import { shelterIDChoices } from '$lib/infrastructure/Definitions.svelte'
+	import { recvdFromPkg } from '$lib/infrastructure/stores'
+	import Dropdown from '$lib/infrastructure/Dropdown.svelte'
+	
 </script>
-
+<Dropdown title="From" choiceList={shelterIDChoices} bind:value={$recvdFromPkg.locationOfRescue} />
 <PrevShelterNum />
 <PrevShelterCatId />

--- a/src/lib/infrastructure/Definitions.svelte
+++ b/src/lib/infrastructure/Definitions.svelte
@@ -35,4 +35,31 @@
 		feralChoicesSemiferal,
 		feralChoicesFeral
 	]
+
+	export const shelterIDOther = 'Other'
+	export const shelterIDSFAS = 'SFAS'
+	export const shelterIDEH = 'EH'
+	export const shelterIDABQ = 'ABQ'
+	export const shelterIDROS = 'ROS'
+	export const shelterIDFK = 'FK'
+	export const shelterIDKHS = 'KHS'
+	export const shelterIDPORT = 'PORT'
+	export const shelterIDART = 'ART'
+	export const shelterIDSNC = 'SNC'
+	export const shelterIDSCH = 'SCH'
+	export const shelterIDVC = 'VC'
+	export const shelterIDChoices = [
+	    shelterIDOther,
+	    shelterIDSFAS,
+	    shelterIDEH,
+        shelterIDABQ,
+	    shelterIDROS,
+	    shelterIDFK,
+	    shelterIDKHS,
+	    shelterIDPORT,
+	    shelterIDART,
+	    shelterIDSNC,
+	    shelterIDSCH,
+	    shelterIDVC
+	]
 </script>

--- a/src/routes/RescueSurrenderForm.svelte
+++ b/src/routes/RescueSurrenderForm.svelte
@@ -6,7 +6,6 @@
 	import ReceivedFromContactInfo from '$lib/components/ReceivedFromContactInfo.svelte'
 	import BreedColorMarkings from '$lib/components/BreedColorMarkings.svelte'
 	import OkWith from '$lib/components/OkWith.svelte'
-	import RescueLocation from '$lib/components/RescueLocation.svelte'
 	import Donation from '$lib/components/Donation.svelte'
 	import IntakeDate from '$lib/components/IntakeDate.svelte'
 	import PrevShelterInfo from '$lib/components/PrevShelterInfo.svelte'
@@ -74,7 +73,6 @@
 
 	<fieldset>
 		<legend>Rescue</legend>
-		<RescueLocation />
 		<PrevShelterInfo />
 	</fieldset>
 


### PR DESCRIPTION
Add dropdown menu of shelter ids to Rescue form, eliminating text box for location of rescue. 